### PR TITLE
implemented new informed trader 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+.pytest_cache/
 
 # Virtual environment
 venv/
@@ -11,6 +12,7 @@ venv/
 # Logs and databases
 *.log
 *.sqlite
+logs/
 
 # Secrets folder contents (but not the folder itself)
 _secrets/*

--- a/client_connector/trader_manager.py
+++ b/client_connector/trader_manager.py
@@ -7,7 +7,7 @@ so they can communicate with them.
 import uuid
 
 from external_traders.noise_trader import get_signal_noise, settings_noise, settings, get_noise_rule_unif
-from external_traders.informed_naive import get_informed_time_plan, get_signal_informed, get_informed_order, settings_informed, informed_state
+from external_traders.informed_naive import get_signal_informed, get_order_to_match, settings_informed, update_settings_informed
 from structures import TraderCreationData
 from typing import List
 from traders import HumanTrader, NoiseTrader, InformedTrader
@@ -45,24 +45,26 @@ class TraderManager:
         # TODO: we may start launching with more than one human trader later.
         # So far for debugging purposes we only need one human trader whose id we return to the client
         n_human_traders = params.get("num_human_traders", 1)
-        activity_frequency = params.get("activity_frequency", 5)
         self.noise_warm_ups = params.get("noise_warm_ups", 10)
 
-        self.noise_traders = [NoiseTrader(activity_frequency=activity_frequency, 
+        self.noise_traders = [NoiseTrader(activity_frequency=params.get('activity_frequency'),
+                                          order_amount=params.get('order_amount'), 
                                           settings=settings,
                                           settings_noise=settings_noise,
                                           get_signal_noise=get_signal_noise,
                                           get_noise_rule_unif=get_noise_rule_unif) for _ in range(n_noise_traders)]
 
-
-        self.informed_traders = [InformedTrader(activity_frequency=activity_frequency, 
+        settings_informed['time_period_in_min'] = params.get('trading_day_duration')
+        settings_informed['trade_intensity'] = params.get('trade_intensity_informed')
+        settings_informed['direction'] = params.get('trade_direction_informed')
+        updated_settings_informed, informed_time_plan, informed_state = update_settings_informed(settings_informed)
+        self.informed_traders = [InformedTrader(activity_frequency=params.get('activity_frequency'), 
                                                 settings=settings, 
-                                                settings_informed=settings_informed, 
-                                                informed_state=informed_state, 
-                                                trading_day_duration=params.get('trading_day_duration', 5),
-                                                get_informed_time_plan=get_informed_time_plan, 
+                                                settings_informed=updated_settings_informed, 
+                                                informed_time_plan=informed_time_plan,
+                                                informed_state=informed_state,
                                                 get_signal_informed=get_signal_informed,
-                                                get_informed_order=get_informed_order) for _ in range(n_informed_traders)]
+                                                get_order_to_match=get_order_to_match) for _ in range(n_informed_traders)]
                 
         self.human_traders = [HumanTrader(cash=cash, shares=shares) for _ in range(n_human_traders)]
 

--- a/external_traders/informed_naive.py
+++ b/external_traders/informed_naive.py
@@ -1,49 +1,57 @@
 import numpy as np
 
 
-settings = {'levels_n': 10,  # int
-            'initial_price': 2000,  # this implies a spread of 5bps
-            }
+settings = {
+    "levels_n": 10,  # int
+    "initial_price": 2000,  # this implies a spread of 5bps
+}
 
 # this settings are received by the platform
 # we need:
 # (1) time period of the round (e.g. 3 minutes)
 # (2) trade intensity (e.g. she will trade 30% of the total orders)
 # (3) to buy or sell
-settings_informed = {'time_period_in_min': 5, 'trade_intensity': 0.10, 'direction': 'sell'}
+settings_informed = {
+    "time_period_in_min": 5,
+    "trade_intensity": 0.10,
+    "direction": "sell",
+}
 
 # given that all the rest should run without any change
 
 
-settings_informed['total_seconds'] = settings_informed['time_period_in_min'] * 60
-settings_informed['inv'] = int(settings_informed['total_seconds'] * settings_informed['trade_intensity'] )
-settings_informed['sn'] = (settings_informed['total_seconds'] - 10) / settings_informed['inv']
+def update_settings_informed(settings_informed):
+    settings_informed["total_seconds"] = settings_informed["time_period_in_min"] * 60
+    settings_informed["inv"] = int(
+        settings_informed["total_seconds"] * settings_informed["trade_intensity"]
+    )
+    settings_informed["sn"] = (
+        settings_informed["total_seconds"] - 10
+    ) / settings_informed["inv"]
 
+    time_plan = [settings_informed["sn"]] * settings_informed["inv"]
+    informed_time_plan = {"period": np.cumsum(time_plan)}
 
-time_plan = [settings_informed['sn']] * settings_informed['inv']
-informed_time_plan = {'period': np.cumsum(time_plan)}
-
-
-def get_informed_state(settings_informed):
-    if settings_informed['direction'] == 'sell':
-        informed_state = {'inv': settings_informed['inv']}
+    if settings_informed["direction"] == "sell":
+        informed_state = {"inv": settings_informed["inv"]}
     else:
-        informed_state = {'inv': -settings_informed['inv']}
-    
-    return informed_state
+        informed_state = {"inv": -settings_informed["inv"]}
 
-informed_state = get_informed_state(settings_informed)
+    return settings_informed, informed_time_plan, informed_state
 
 
+settings_informed, informed_time_plan, informed_state = update_settings_informed(
+    settings_informed
+)
 
 
 def get_signal_informed(informed_state, settings_informed, informed_time_plan, time):
     # time here is the clock time measured by the platform
     # if this is not convenient, Wenbin propose something else
-    
-    times_to_act = informed_time_plan['period'].astype(int)
-    
-    if time in times_to_act and informed_state['inv'] !=0 :
+
+    times_to_act = informed_time_plan["period"].astype(int)
+
+    if time in times_to_act and informed_state["inv"] != 0:
         action = 1
         shares = 1
     else:
@@ -54,25 +62,26 @@ def get_signal_informed(informed_state, settings_informed, informed_time_plan, t
 
     return signal_informed
 
-def get_informed_order(book, informed_state,settings_informed, settings,time):
 
+def get_order_to_match(
+    book, signal_informed, informed_state, settings_informed, settings, time
+):
     # the informed trader can only sell (if init_inv>0) or buy (if init_inv<0)
-    signal_informed = get_signal_informed(informed_state, settings_informed, informed_time_plan, time)
+    # print(signal_informed)
     action = signal_informed[0]
     num_shares = signal_informed[1]
-    
-    if action == 1 and settings_informed['direction'] == 'sell':
-        price = book[ind_bid_price[0]]
-        order = {'bid': {price: [num_shares]}, 'ask': {}}
-        informed_state['inv'] -= 1
-        
-    if action == 1 and settings_informed['direction'] == 'buy':
-        price = book[ind_ask_price[0]]
-        order = {'bid': {}, 'ask': {price: [num_shares]}}
-        informed_state['inv'] += 1
-        
+
+    if action == 1 and settings_informed["direction"] == "sell":
+        price = book[2]  # best bid
+        order = {"bid": {price: [num_shares]}, "ask": {}}
+        informed_state["inv"] -= 1
+
+    if action == 1 and settings_informed["direction"] == "buy":
+        price = book[0]  # best ask
+        order = {"bid": {}, "ask": {price: [num_shares]}}
+        informed_state["inv"] += 1
+
     if action == 0:
         order = {}
 
     return order
-c

--- a/external_traders/informed_naive.py
+++ b/external_traders/informed_naive.py
@@ -1,63 +1,51 @@
-
-import random
-
 import numpy as np
-
-import datetime
-import random
 
 
 settings = {'levels_n': 10,  # int
             'initial_price': 2000,  # this implies a spread of 5bps
-            'stack_max_size': 2,  # int
-            'time_thresh': 1000,  # int how much to wait for a stack reset
-            'n_updates_session': 900,  # if a session is 15min, then an update every 1secs
-            'warmup_periods': 100,  # how may period we run the noise trader before starting
-            'alphas_ewma': [0., .5, .95, .98]
-            # other settings...
             }
 
-settings_informed = {'inv': 100}
+# this settings are received by the platform
+# we need:
+# (1) time period of the round (e.g. 3 minutes)
+# (2) trade intensity (e.g. she will trade 30% of the total orders)
+# (3) to buy or sell
+settings_informed = {'time_period_in_min': 5, 'trade_intensity': 0.10, 'direction': 'sell'}
 
-informed_state = {'inv': settings_informed['inv'], 'outstanding_orders': {'bid': {}, 'ask': {}}}
+# given that all the rest should run without any change
 
 
-def get_informed_time_plan(settings_informed,settings):
-    n_updates = settings['n_updates_session']
-    inv_to_sell = settings_informed['inv']
-    shares_per_period = inv_to_sell / n_updates # how many shares should sell in each time update
+settings_informed['total_seconds'] = settings_informed['time_period_in_min'] * 60
+settings_informed['inv'] = int(settings_informed['total_seconds'] * settings_informed['trade_intensity'] )
+settings_informed['sn'] = (settings_informed['total_seconds'] - 10) / settings_informed['inv']
 
-    if shares_per_period < 1 :
-        time_periods_to_wait = int(round(1 / shares_per_period))
-        time_periods_to_sell = list(np.arange(1, n_updates, time_periods_to_wait))
-        shares_each_period = [1] * len(time_periods_to_sell)
+
+time_plan = [settings_informed['sn']] * settings_informed['inv']
+informed_time_plan = {'period': np.cumsum(time_plan)}
+
+
+def get_informed_state(settings_informed):
+    if settings_informed['direction'] == 'sell':
+        informed_state = {'inv': settings_informed['inv']}
     else:
-        shares_each_period = int(-(-shares_per_period // 1))
-        periods_needed = int(inv_to_sell / shares_each_period)
-        time_periods_to_sell = list(np.arange(1, periods_needed + 1, 1))
-        shares_each_period = [shares_each_period] * periods_needed
+        informed_state = {'inv': -settings_informed['inv']}
+    
+    return informed_state
 
-    informed_time_plan = {'period': time_periods_to_sell , 'shares': shares_each_period}
-    return informed_time_plan
+informed_state = get_informed_state(settings_informed)
 
 
-settings_informed.update(get_informed_time_plan(settings_informed, settings))
 
 
-def get_signal_informed(informed_state, settings_informed, time):
-    # time is the time count from to 100 to 1000 (100 warmup + sessions)
-    time_count = time - settings['warmup_periods'] + 1
-
-    current_inv = informed_state['inv']
-
-    times_to_sell = settings_informed['period']
-    shares_to_sell = settings_informed['shares']
-
-    if time_count in times_to_sell:
+def get_signal_informed(informed_state, settings_informed, informed_time_plan, time):
+    # time here is the clock time measured by the platform
+    # if this is not convenient, Wenbin propose something else
+    
+    times_to_act = informed_time_plan['period'].astype(int)
+    
+    if time in times_to_act and informed_state['inv'] !=0 :
         action = 1
-        which = (time_count == np.array(times_to_sell))
-        shares = int(np.array(shares_to_sell)[which])
-        informed_state['inv'] = current_inv - shares  # update inventory of informed trader
+        shares = 1
     else:
         action = 0
         shares = 0
@@ -66,18 +54,25 @@ def get_signal_informed(informed_state, settings_informed, time):
 
     return signal_informed
 
-def get_informed_order(book, message, signal_informed, informed_state,settings_informed, settings):
+def get_informed_order(book, informed_state,settings_informed, settings,time):
 
     # the informed trader can only sell (if init_inv>0) or buy (if init_inv<0)
+    signal_informed = get_signal_informed(informed_state, settings_informed, informed_time_plan, time)
     action = signal_informed[0]
     num_shares = signal_informed[1]
-    if action == 1 and settings_informed['inv'] > 0:
+    
+    if action == 1 and settings_informed['direction'] == 'sell':
         price = book[ind_bid_price[0]]
         order = {'bid': {price: [num_shares]}, 'ask': {}}
-    if action == 1 and settings_informed['inv'] < 0:
+        informed_state['inv'] -= 1
+        
+    if action == 1 and settings_informed['direction'] == 'buy':
         price = book[ind_ask_price[0]]
         order = {'bid': {}, 'ask': {price: [num_shares]}}
+        informed_state['inv'] += 1
+        
     if action == 0:
         order = {}
 
     return order
+c

--- a/external_traders/noise_trader.py
+++ b/external_traders/noise_trader.py
@@ -432,7 +432,7 @@ def get_market_maker_order(book, message, signal_market_maker, market_maker_stat
     return order
 
 
-def get_informed_order(book, message, signal_informed, informed_state,
+def get_order_to_match(book, message, signal_informed, informed_state,
                        settings_informed, settings):
     # do someting and get order in the following format
     # order = {'bid':{2003:4,2002:1}, 'ask': {2011:1,2016:2,2018:1}}

--- a/main_platform/trading_platform.py
+++ b/main_platform/trading_platform.py
@@ -52,11 +52,12 @@ class TradingSession:
         self.release_task = None
         self.lock = Lock()
         self.release_event = Event()
+        self.current_price = 0 # handling non-defined attribute
 
     @property
     def current_time(self):
         return datetime.now(timezone.utc)
-
+    
     @property
     def mid_price(self) -> float:
         return self.current_price or self.default_price
@@ -187,7 +188,7 @@ class TradingSession:
                 'spread': spread,
                 'midpoint': midpoint,
 
-                'transaction_price': self.transaction_price
+                'transaction_price': self.transaction_price,
             })
 
         exchange = await self.channel.get_exchange(self.broadcast_exchange_name)
@@ -217,7 +218,7 @@ class TradingSession:
             'spread': spread,
             'mid_price': mid_price,
 
-            'current_price': current_price
+            'current_price': current_price,
         })
         await self.trader_exchange.publish(
             aio_pika.Message(body=json.dumps(message, cls=CustomEncoder).encode()),

--- a/main_platform/utils.py
+++ b/main_platform/utils.py
@@ -15,7 +15,6 @@ import asyncio
 import os
 import csv
 from main_platform.custom_logger import setup_custom_logger
-import polars as pl
 
 from pydantic import BaseModel
 np.set_printoptions(floatmode='fixed', precision=0)

--- a/main_platform/utils.py
+++ b/main_platform/utils.py
@@ -15,6 +15,7 @@ import asyncio
 import os
 import csv
 from main_platform.custom_logger import setup_custom_logger
+import polars as pl
 
 from pydantic import BaseModel
 np.set_printoptions(floatmode='fixed', precision=0)
@@ -164,10 +165,10 @@ def convert_to_book_format(active_orders, levels_n=10, default_price=2000):
     df = df.astype({"price": int, "amount": int})
 
     # Aggregate orders by price, summing the amounts
-    df_asks = df[df['order_type'] == OrderType.ASK.value].groupby('price')['amount'].sum().reset_index().sort_values(
+    df_asks = df[df['order_type'] == 'ask'].groupby('price')['amount'].sum().reset_index().sort_values(
         by='price').head(
         levels_n)
-    df_bids = df[df['order_type'] == OrderType.BID.value].groupby('price')['amount'].sum().reset_index().sort_values(
+    df_bids = df[df['order_type'] == 'bid'].groupby('price')['amount'].sum().reset_index().sort_values(
         by='price',
         ascending=False).head(
         levels_n)
@@ -206,7 +207,6 @@ def convert_to_noise_state(active_orders: List[Dict]) -> Dict:
             amount = order['amount']
             noise_state['outstanding_orders'][order_type][price] += amount
 
-    # Convert defaultdicts to regular dicts for easier use later
     noise_state['outstanding_orders']['bid'] = dict(noise_state['outstanding_orders']['bid'])
     noise_state['outstanding_orders']['ask'] = dict(noise_state['outstanding_orders']['ask'])
 

--- a/structures/structures.py
+++ b/structures/structures.py
@@ -14,6 +14,10 @@ def now():
 GOALS = [-10, 0, 10]  # for now let's try a naive hardcoded approach to the goals
 
 
+class TradeDirection(str, Enum):
+    BUY = 'buy'
+    SELL = 'sell'
+
 class TraderCreationData(BaseModel):
     num_human_traders: int = Field(
         default=1,
@@ -28,28 +32,37 @@ class TraderCreationData(BaseModel):
         ge=0
     )
     num_informed_traders: int = Field(
-        default=0,
+        default=1,
         title="Number of Informed Traders",
         description="Number of informed traders",
         ge=0
     )
-    activity_frequency: float = Field(
-        default=1.0,
-        title="Activity Frequency",
-        description="Frequency of noise traders' updates in seconds",
-        gt=0
-    )
     trading_day_duration: int = Field(
-        default=100,
+        default=1,
         title="Trading Day Duration",
         description="Duration of the trading day in minutes",
         gt=0
     )
-    step: int = Field(
-        default=1,
-        title="Step for New Orders",
-        description="Step for new orders",
+    activity_frequency: float = Field(
+        default=1.0,
+        title="Noise Trader: Activity Frequency",
+        description="Frequency of noise traders' updates in seconds",
         gt=0
+    )
+    order_amount: int = Field(
+        default=1,
+        title="Noise Trader: Order Amount",
+        description="Order amount for noise traders",
+    )
+    trade_intensity_informed: float = Field(
+        default=0.1,
+        title="Informed Trader: Trade Intensity",
+        description="Trade intensity for informed traders, e.g. she will trade 30 percent of the total orders",
+    )
+    trade_direction_informed: TradeDirection = Field(
+        default=TradeDirection.SELL,
+        title="Informed Trader: Trade Direction",
+        description="Trade direction for informed traders, to sell or buy",
     )
     noise_warm_ups: int = Field(
         default=10,
@@ -139,4 +152,3 @@ class TransactionModel(BaseModel):
     price: float
 
 
-ORDER_AMOUNT = 1

--- a/structures/structures.py
+++ b/structures/structures.py
@@ -1,5 +1,5 @@
 from enum import Enum, IntEnum, StrEnum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from typing import Optional
 from uuid import UUID, uuid4
 from datetime import datetime, timezone
@@ -140,7 +140,7 @@ class Order(BaseModel):
     session_id: str
     trader_id: str
 
-    class Config:
+    class ConfigDict:
         use_enum_values = True  # This ensures that enum values are used in serialization
 
 

--- a/tests/test_informed_trader.py
+++ b/tests/test_informed_trader.py
@@ -5,9 +5,7 @@ from structures import TraderType, OrderType
 
 @pytest.fixture
 def informed_trader_settings():
-    # Assuming get_informed_state is a function that initializes the informed_state
-    # For testing, you can mock it or provide a fixed dictionary
-    informed_state = {"inv": 1}  # Example initial state
+    informed_state = {"inv": 1} 
 
     return {
         "activity_frequency": 10,
@@ -16,12 +14,10 @@ def informed_trader_settings():
             "n_updates_session": 10,
             "warmup_periods": 2,
         },
-        "settings_informed": {"inv": 1, "direction": "sell"},  # Added 'direction' for completeness
-        "informed_time_plan": {"period": [10, 20, 30]},  # Example time plan
+        "settings_informed": {"inv": 1, "direction": "sell"}, 
+        "informed_time_plan": {"period": [10, 20, 30]},
         "informed_state": informed_state,
-        "get_signal_informed": MagicMock(return_value=[1, 100]),  # Mock as before
-        # Assuming get_order_to_match should return a realistic order dict based on the signal
-        # For a sell signal, it might return a bid order to be matched with an ask
+        "get_signal_informed": MagicMock(return_value=[1, 100]),  
         "get_order_to_match": MagicMock(return_value={"bid": {100: [1]}, "ask": {}}),
     }
 
@@ -33,7 +29,6 @@ def test_initialization(informed_trader):
     assert informed_trader.activity_frequency == 10
     assert informed_trader.settings["initial_price"] == 100
     assert informed_trader.trader_type == TraderType.INFORMED
-    # Test the initialization of informed_state and settings_informed
     assert informed_trader.informed_state == {"inv": 1}
     assert informed_trader.settings_informed["direction"] == "sell"
 
@@ -41,6 +36,4 @@ def test_initialization(informed_trader):
 async def test_act_generates_orders(informed_trader):
     informed_trader.post_new_order = AsyncMock()
     await informed_trader.act()
-    # Verify post_new_order was called with the correct parameters
-    # Since the mock get_order_to_match returns a bid order, we expect an ask order to be posted
     informed_trader.post_new_order.assert_awaited_with(1, 100, OrderType.ASK)

--- a/tests/test_informed_trader.py
+++ b/tests/test_informed_trader.py
@@ -1,11 +1,14 @@
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 from traders import InformedTrader
-from structures import TraderType
-
+from structures import TraderType, OrderType
 
 @pytest.fixture
 def informed_trader_settings():
+    # Assuming get_informed_state is a function that initializes the informed_state
+    # For testing, you can mock it or provide a fixed dictionary
+    informed_state = {"inv": 1}  # Example initial state
+
     return {
         "activity_frequency": 10,
         "settings": {
@@ -13,40 +16,31 @@ def informed_trader_settings():
             "n_updates_session": 10,
             "warmup_periods": 2,
         },
-        "settings_informed": {"inv": 1},
-        "informed_state": {},
-        "trading_day_duration": 8,
-        "get_informed_time_plan": MagicMock(return_value=[]),
-        "get_signal_informed": MagicMock(return_value=[1, 100]),
-        "get_order_to_match": MagicMock(return_value={}),
+        "settings_informed": {"inv": 1, "direction": "sell"},  # Added 'direction' for completeness
+        "informed_time_plan": {"period": [10, 20, 30]},  # Example time plan
+        "informed_state": informed_state,
+        "get_signal_informed": MagicMock(return_value=[1, 100]),  # Mock as before
+        # Assuming get_order_to_match should return a realistic order dict based on the signal
+        # For a sell signal, it might return a bid order to be matched with an ask
+        "get_order_to_match": MagicMock(return_value={"bid": {100: [1]}, "ask": {}}),
     }
-
 
 @pytest.fixture
 def informed_trader(informed_trader_settings):
     return InformedTrader(**informed_trader_settings)
 
-
 def test_initialization(informed_trader):
     assert informed_trader.activity_frequency == 10
     assert informed_trader.settings["initial_price"] == 100
     assert informed_trader.trader_type == TraderType.INFORMED
-
-
-def test_get_best_bid_and_ask(informed_trader):
-    informed_trader.active_orders = [
-        {"order_type": "bid", "price": 101},
-        {"order_type": "ask", "price": 105},
-        {"order_type": "bid", "price": 102},
-        {"order_type": "ask", "price": 104},
-    ]
-    best_bid, best_ask = informed_trader.get_best_bid_and_ask()
-    assert best_bid["price"] == 102, "Expect the highest bid"
-    assert best_ask["price"] == 104, "Expect the lowest ask"
-
+    # Test the initialization of informed_state and settings_informed
+    assert informed_trader.informed_state == {"inv": 1}
+    assert informed_trader.settings_informed["direction"] == "sell"
 
 @pytest.mark.asyncio
 async def test_act_generates_orders(informed_trader):
     informed_trader.post_new_order = AsyncMock()
     await informed_trader.act()
-    informed_trader.post_new_order.assert_awaited()
+    # Verify post_new_order was called with the correct parameters
+    # Since the mock get_order_to_match returns a bid order, we expect an ask order to be posted
+    informed_trader.post_new_order.assert_awaited_with(1, 100, OrderType.ASK)

--- a/tests/test_informed_trader.py
+++ b/tests/test_informed_trader.py
@@ -1,0 +1,52 @@
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+from traders import InformedTrader
+from structures import TraderType
+
+
+@pytest.fixture
+def informed_trader_settings():
+    return {
+        "activity_frequency": 10,
+        "settings": {
+            "initial_price": 100,
+            "n_updates_session": 10,
+            "warmup_periods": 2,
+        },
+        "settings_informed": {"inv": 1},
+        "informed_state": {},
+        "trading_day_duration": 8,
+        "get_informed_time_plan": MagicMock(return_value=[]),
+        "get_signal_informed": MagicMock(return_value=[1, 100]),
+        "get_informed_order": MagicMock(return_value={}),
+    }
+
+
+@pytest.fixture
+def informed_trader(informed_trader_settings):
+    return InformedTrader(**informed_trader_settings)
+
+
+def test_initialization(informed_trader):
+    assert informed_trader.activity_frequency == 10
+    assert informed_trader.settings["initial_price"] == 100
+    assert informed_trader.trader_type == TraderType.INFORMED
+
+
+def test_get_best_bid_and_ask(informed_trader):
+    informed_trader.active_orders = [
+        {"order_type": "bid", "price": 101},
+        {"order_type": "ask", "price": 105},
+        {"order_type": "bid", "price": 102},
+        {"order_type": "ask", "price": 104},
+    ]
+    best_bid, best_ask = informed_trader.get_best_bid_and_ask()
+    assert best_bid["price"] == 102, "Expect the highest bid"
+    assert best_ask["price"] == 104, "Expect the lowest ask"
+
+
+@pytest.mark.asyncio
+async def test_act_generates_orders(informed_trader):
+    informed_trader.post_new_order = AsyncMock()
+    await informed_trader.act()
+    informed_trader.post_new_order.assert_awaited()

--- a/tests/test_informed_trader.py
+++ b/tests/test_informed_trader.py
@@ -18,7 +18,7 @@ def informed_trader_settings():
         "trading_day_duration": 8,
         "get_informed_time_plan": MagicMock(return_value=[]),
         "get_signal_informed": MagicMock(return_value=[1, 100]),
-        "get_informed_order": MagicMock(return_value={}),
+        "get_order_to_match": MagicMock(return_value={}),
     }
 
 

--- a/tests/test_noise_trader.py
+++ b/tests/test_noise_trader.py
@@ -7,7 +7,7 @@ from structures import TraderType
 def noise_trader_settings():
     return {
         "activity_frequency": 1.0,
-        "order_amount": 10,  # Example new parameter
+        "order_amount": 1,
         "settings": {"initial_price": 100},
         "settings_noise": {},
         "get_signal_noise": lambda signal_state, settings_noise: {},

--- a/tests/test_noise_trader.py
+++ b/tests/test_noise_trader.py
@@ -7,12 +7,12 @@ from structures import TraderType
 def noise_trader_settings():
     return {
         "activity_frequency": 1.0,
+        "order_amount": 10,  # Example new parameter
         "settings": {"initial_price": 100},
         "settings_noise": {},
         "get_signal_noise": lambda signal_state, settings_noise: {},
         "get_noise_rule_unif": lambda book_format, signal_noise, noise_state, settings_noise, settings: [],
     }
-
 
 @pytest.fixture
 def noise_trader(noise_trader_settings):

--- a/tests/test_noise_trader.py
+++ b/tests/test_noise_trader.py
@@ -1,0 +1,58 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from traders import NoiseTrader
+from structures import TraderType
+
+@pytest.fixture
+def noise_trader_settings():
+    return {
+        "activity_frequency": 1.0,
+        "settings": {"initial_price": 100},
+        "settings_noise": {},
+        "get_signal_noise": lambda signal_state, settings_noise: {},
+        "get_noise_rule_unif": lambda book_format, signal_noise, noise_state, settings_noise, settings: [],
+    }
+
+
+@pytest.fixture
+def noise_trader(noise_trader_settings):
+    return NoiseTrader(**noise_trader_settings)
+
+
+def test_initialization(noise_trader):
+    assert noise_trader.activity_frequency == 1.0
+    assert noise_trader.settings["initial_price"] == 100
+    assert noise_trader.current_variance == 5.0
+    assert noise_trader.trader_type == TraderType.NOISE
+
+
+def test_cooling_interval(noise_trader):
+    target = 5.0
+    interval = noise_trader.cooling_interval(target)
+    assert interval >= 0, "Interval should be non-negative"
+
+
+@pytest.mark.asyncio
+async def test_act_with_no_active_orders(noise_trader):
+    noise_trader.active_orders = []
+    noise_trader.post_new_order = AsyncMock()
+    await noise_trader.act()
+    noise_trader.post_new_order.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_process_order_add_order(noise_trader):
+    noise_trader.post_new_order = AsyncMock()
+    order = {"action_type": "add_order", "order_type": "ask", "price": 100, "amount": 1}
+    await noise_trader.process_order(order)
+    noise_trader.post_new_order.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_process_order_cancel_order(noise_trader):
+    noise_trader.orders = [{"id": "1", "order_type": "ask"}]
+    noise_trader.send_cancel_order_request = AsyncMock()
+    order = {"action_type": "cancel_order", "order_type": "ask"}
+    with patch("random.choice", return_value={"id": "1"}):
+        await noise_trader.process_order(order)
+    noise_trader.send_cancel_order_request.assert_awaited_once_with("1")

--- a/tests/test_trading_session.py
+++ b/tests/test_trading_session.py
@@ -1,0 +1,161 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, patch
+from main_platform import TradingSession
+from structures import OrderStatus, OrderType
+
+
+@pytest.mark.asyncio
+async def test_initialize():
+    session = TradingSession(duration=1)
+    session.connection = AsyncMock()
+    session.channel = AsyncMock()
+    with patch("aio_pika.connect_robust", return_value=session.connection), patch(
+        "main_platform.trading_platform.now", return_value="2023-04-01T00:00:00Z"
+    ):
+        await session.initialize()
+        session.connection.channel.assert_awaited()
+        session.channel.declare_exchange.assert_awaited()
+        assert session.active is True
+        assert session.start_time == "2023-04-01T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_place_order():
+    session = TradingSession(duration=1)
+    order_dict = {
+        "id": "test_order_id",
+        "order_type": OrderType.BID.value,
+        "amount": 100,
+        "price": 1000,
+        "status": OrderStatus.BUFFERED.value,
+    }
+    placed_order = session.place_order(order_dict)
+    assert placed_order["status"] == OrderStatus.ACTIVE.value
+    assert session.all_orders["test_order_id"] == placed_order
+
+
+@pytest.mark.asyncio
+async def test_order_book_empty():
+    session = TradingSession(duration=1)
+    order_book = session.order_book
+    assert order_book == {
+        "bids": [],
+        "asks": [],
+    }, "Order book should be empty initially"
+
+
+@pytest.mark.asyncio
+async def test_order_book_with_only_bids():
+    session = TradingSession(duration=1)
+    session.all_orders = {
+        "bid_order_1": {
+            "id": "bid_order_1",
+            "order_type": OrderType.BID.value,
+            "price": 1000,
+            "amount": 10,
+            "status": OrderStatus.ACTIVE.value,
+        },
+        "bid_order_2": {
+            "id": "bid_order_2",
+            "order_type": OrderType.BID.value,
+            "price": 1010,
+            "amount": 5,
+            "status": OrderStatus.ACTIVE.value,
+        },
+    }
+    order_book = session.order_book
+    assert order_book["asks"] == [], "Expect no asks in the order book"
+    assert len(order_book["bids"]) == 2, "Expect two bids in the order book"
+    assert (
+        order_book["bids"][0]["x"] == 1010
+    ), "The first bid should have the highest price"
+
+
+@pytest.mark.asyncio
+async def test_order_book_with_only_asks():
+    session = TradingSession(duration=1)
+    session.all_orders = {
+        "ask_order_1": {
+            "id": "ask_order_1",
+            "order_type": OrderType.ASK.value,
+            "price": 1020,
+            "amount": 10,
+            "status": OrderStatus.ACTIVE.value,
+        },
+        "ask_order_2": {
+            "id": "ask_order_2",
+            "order_type": OrderType.ASK.value,
+            "price": 1005,
+            "amount": 5,
+            "status": OrderStatus.ACTIVE.value,
+        },
+    }
+    order_book = session.order_book
+    assert order_book["bids"] == [], "Expect no bids in the order book"
+    assert len(order_book["asks"]) == 2, "Expect two asks in the order book"
+    assert (
+        order_book["asks"][0]["x"] == 1005
+    ), "The first ask should have the lowest price"
+
+
+@pytest.mark.asyncio
+async def test_order_book_with_bids_and_asks():
+    session = TradingSession(duration=1)
+    session.all_orders = {
+        "bid_order": {
+            "id": "bid_order",
+            "order_type": OrderType.BID.value,
+            "price": 1000,
+            "amount": 10,
+            "status": OrderStatus.ACTIVE.value,
+        },
+        "ask_order": {
+            "id": "ask_order",
+            "order_type": OrderType.ASK.value,
+            "price": 1020,
+            "amount": 5,
+            "status": OrderStatus.ACTIVE.value,
+        },
+    }
+    order_book = session.order_book
+    assert len(order_book["bids"]) == 1, "Expect one bid in the order book"
+    assert len(order_book["asks"]) == 1, "Expect one ask in the order book"
+    assert order_book["bids"][0]["x"] == 1000, "The bid price should match"
+    assert order_book["asks"][0]["x"] == 1020, "The ask price should match"
+
+
+@pytest.mark.asyncio
+async def test_get_spread():
+    session = TradingSession(duration=1)
+    session.all_orders = {
+        "ask_order": {
+            "id": "ask_order",
+            "order_type": OrderType.ASK.value,
+            "price": 1010,
+            "timestamp": "2023-04-01T00:00:10Z",
+            "status": OrderStatus.ACTIVE.value,
+        },
+        "bid_order": {
+            "id": "bid_order",
+            "order_type": OrderType.BID.value,
+            "price": 1000,
+            "timestamp": "2023-04-01T00:00:05Z",
+            "status": OrderStatus.ACTIVE.value,
+        },
+    }
+    spread = session.get_spread()
+    assert spread == 10
+
+
+@pytest.mark.asyncio
+async def test_clean_up():
+    session = TradingSession(duration=1)
+    session.connection = AsyncMock()
+    session.channel = AsyncMock()
+    session._stop_requested = asyncio.Event()
+    session._stop_requested.set()
+    await session.clean_up()
+    session.channel.close.assert_awaited()
+    session.connection.close.assert_awaited()
+    assert session.active is False

--- a/tests/test_trading_session.py
+++ b/tests/test_trading_session.py
@@ -145,7 +145,7 @@ async def test_get_spread():
         },
     }
     spread = session.get_spread()
-    assert spread == 10
+    assert spread[0] == 10
 
 
 @pytest.mark.asyncio

--- a/traders/base_trader.py
+++ b/traders/base_trader.py
@@ -54,7 +54,16 @@ class BaseTrader:
         self.sum_mid_executions = 0
         self.current_pnl = 0
 
+        self.start_time = asyncio.get_event_loop().time()
+
+
         # END PNL BLOCK
+
+    def get_elapsed_time(self) -> float:
+        """Returns the elapsed time in seconds since the trader was initialized."""
+        current_time = asyncio.get_event_loop().time()
+        return current_time - self.start_time
+
     def get_vwap(self):
         # let's for now just return the average of all transaction prices
         return sum(self.transaction_prices) / len(self.transaction_prices) if self.transaction_prices else 0
@@ -85,6 +94,7 @@ class BaseTrader:
             return pnl_adjusted
         return self.current_pnl
 
+    
     @property
     def delta_cash(self):
         return self.cash - self.initial_cash

--- a/traders/human_trader.py
+++ b/traders/human_trader.py
@@ -91,7 +91,7 @@ class HumanTrader(BaseTrader):
         except json.JSONDecodeError:
             logger.critical(f"Error decoding message: {message}")
 
-    async def handle_(self, data):
+    async def handle_add_order(self, data):
         order_type = data.get('type')  # TODO: Philipp. This is a string. We need to convert it to an enum.
         # TODO. Philipp. We may rewrite a client so it will send us an enum instead of a string.
         if order_type == 'bid':

--- a/traders/human_trader.py
+++ b/traders/human_trader.py
@@ -13,7 +13,7 @@ class HumanTrader(BaseTrader):
     websocket = None
     socket_status = False
     inventory = {'shares': 0, 'cash': 1000}  # TODO.PHILIPP. WRite something sensible here. placeholder for now.
-
+    
     def __init__(self, *args, **kwargs):
         super().__init__(trader_type=TraderType.HUMAN, *args, **kwargs)
         self.goal = random.choice(GOALS)
@@ -91,7 +91,7 @@ class HumanTrader(BaseTrader):
         except json.JSONDecodeError:
             logger.critical(f"Error decoding message: {message}")
 
-    async def handle_add_order(self, data):
+    async def handle_(self, data):
         order_type = data.get('type')  # TODO: Philipp. This is a string. We need to convert it to an enum.
         # TODO. Philipp. We may rewrite a client so it will send us an enum instead of a string.
         if order_type == 'bid':

--- a/traders/informed_trader.py
+++ b/traders/informed_trader.py
@@ -3,24 +3,22 @@ import random
 from datetime import datetime
 from structures import OrderType, TraderType
 from main_platform.custom_logger import setup_custom_logger
-from main_platform.utils import now
+from main_platform.utils import convert_to_book_format
 from .base_trader import BaseTrader
 
 logger = setup_custom_logger(__name__)
 
 
 class InformedTrader(BaseTrader):
-
     def __init__(
         self,
         activity_frequency: int,
         settings: dict,
         settings_informed: dict,
+        informed_time_plan: dict,
         informed_state: dict,
-        trading_day_duration: int,
-        get_informed_time_plan: callable,
         get_signal_informed: callable,
-        get_informed_order: callable,
+        get_order_to_match: callable,
     ):
         """
         initializes the informed trader with settings and callable functions.
@@ -29,100 +27,54 @@ class InformedTrader(BaseTrader):
         self.activity_frequency = activity_frequency
         self.settings = settings
         self.settings_informed = settings_informed
+        self.informed_time_plan = informed_time_plan
         self.informed_state = informed_state
-        self.trading_day_duration = trading_day_duration
-        self.get_informed_time_plan = get_informed_time_plan
         self.get_signal_informed = get_signal_informed
-        self.time_plan = self.get_informed_time_plan(
-            self.settings_informed, self.settings
-        )
-        self.step_frequency = (
-            self.trading_day_duration
-            * 60
-            / (self.settings["n_updates_session"] + self.settings["warmup_periods"])
-        )
-
-        self.current_step = 0
-
-    @property
-    def current_time(self) -> datetime:
-        """
-        a temporary solution to map time to step.
-        """
-        return now()
-
-    def get_best_bid_and_ask(self) -> tuple:
-        """
-        a helper function to decide on price.
-        """
-        best_bid = None
-        best_ask = None
-
-        for order in self.active_orders:
-            if order["order_type"] == "bid":
-                if best_bid is None or order["price"] > best_bid["price"]:
-                    best_bid = order
-            elif order["order_type"] == "ask":
-                if best_ask is None or order["price"] < best_ask["price"]:
-                    best_ask = order
-
-        return best_bid, best_ask
-
-    def get_informed_order(
-        self, signal_informed: list, settings_informed: dict
-    ) -> dict:
-        """
-        generates informed trader's orders.
-        TODO
-        THE PRICE SHOULD BE LEARNED FROM PROFITS AND LOSSES.
-        """
-        action, num_shares = signal_informed[0], signal_informed[1]
-        best_bid, best_ask = self.get_best_bid_and_ask()
-        order = {}
-        price_variation = random.randint(1, 10)
-
-        if action == 1:
-            if settings_informed["inv"] > 0:
-                price = (
-                    (best_ask["price"] - price_variation)
-                    if best_ask
-                    else self.settings["initial_price"] - price_variation
-                )
-                order = {"bid": {price: [num_shares]}, "ask": {}}
-            elif settings_informed["inv"] < 0:
-                price = (
-                    (best_bid["price"] + price_variation)
-                    if best_bid
-                    else self.settings["initial_price"] + price_variation
-                )
-                order = {"bid": {}, "ask": {price: [num_shares]}}
-
-        return order
+        self.get_order_to_match = get_order_to_match
 
     async def act(self):
         """
-        loads step-wise signal and generates orders.
+        Loads signal and generates orders.
         """
-        signal = self.get_signal_informed(
-            self.informed_state, self.settings_informed, self.current_step
-        )
-        order_dict = self.get_informed_order(signal, self.settings_informed)
+        # prep the order book based on active orders
+        book = convert_to_book_format(self.active_orders)
 
-        for order_type, orders in order_dict.items():
-            for price, amounts in orders.items():
-                for amount in amounts:
-                    if order_type == "bid":
-                        await self.post_new_order(amount, price, OrderType.BID)
-                    elif order_type == "ask":
-                        await self.post_new_order(amount, price, OrderType.ASK)
-                    logger.info(
-                        "POSTED %s AT %s AMOUNT %s AT STEP %s AT TIME %s",
-                        order_type,
-                        price,
-                        amount,
-                        self.current_step,
-                        self.current_time.strftime("%H:%M:%S"),
-                    )
+        elapsed_time_sec = int(self.get_elapsed_time())
+
+        try:
+            signal_informed = self.get_signal_informed(
+                self.informed_state,
+                self.settings_informed,
+                self.informed_time_plan,
+                elapsed_time_sec,
+            )
+            order_dict = self.get_order_to_match(
+                book,
+                signal_informed,
+                self.informed_state,
+                self.settings_informed,
+                self.settings,
+                elapsed_time_sec,
+            )
+
+            for order_type, orders in order_dict.items():
+                for price, amounts in orders.items():
+                    for amount in amounts:
+                        # if the order to be matched is a bid, we send an ask order to match that bid
+                        if order_type == "bid":
+                            await self.post_new_order(amount, price, OrderType.ASK)
+                        # if the order to be matched is an ask, we send a bid order to match that ask
+                        elif order_type == "ask":
+                            await self.post_new_order(amount, price, OrderType.BID)
+                        logger.critical(
+                            "MATCHING %s AT %s AMOUNT %s AT TIME %s",
+                            order_type,
+                            price,
+                            amount,
+                            elapsed_time_sec,
+                        )
+        except Exception as e:
+            print(e)
 
     async def run(self):
         """
@@ -131,8 +83,8 @@ class InformedTrader(BaseTrader):
         while not self._stop_requested.is_set():
             try:
                 await self.act()
-                await asyncio.sleep(self.step_frequency)
-                self.current_step += 1
+                await asyncio.sleep(1)
+
             except asyncio.CancelledError:
                 logger.info(
                     "Run method cancelled, performing cleanup of %s...",


### PR DESCRIPTION
# informed trader update

integrated [updated external noise trader](https://www.dropbox.com/scl/fi/4stvicqyiqyq48oxk0ldw/informed_trader_april_edition.py?rlkey=vmfm3sd06fuqml9g4gq4zqha8&dl=0) into the project. 

## minor changes to the platform:  
1. temporary fix to the main platform to handle missing attribute error
2. updated structures to remove hard coding
3. updated unit tests
4. modified [external noise trader](https://github.com/dthinkr/trader_london/blob/main/external_traders/informed_naive.py) to encapsulate its internal state
5. fixed a naming mistake ```handle_add_order``` in human trader 

## notes:
1. order book matches order continuously. this means every market order of the informed trader will be matched at the desired price, as no faster order can match before the informed order. however, this could be possible given significant latency between the platform and the informed trader. 
2. considering this, it might be beneficial to add a method [here](https://github.com/dthinkr/trader_london/blob/main/main_platform/trading_platform.py) to place a market order. this method ensures an order is finally matched at the best available price. 
 
## unimplemented: 
- [ ] ensure informed trader inventory updates correctly
- [ ] with the latest update, the front end does not display the human traders orders. this means the human trader cannot send valid orders. please take a look at the front end. 
- [ ] why no consistent naming convention for order type? this has lead to issues processing the order book. ```structures.py``` defines ```OrderType```, but the platform converts it back and forth. e.g. ``` active_orders_df['order_type'] = active_orders_df['order_type'].map({-1: 'ask', 1: 'bid'})``` . can there be a definitive way to refer to order types? 

i am now creating this pull request for your review. my work hours may not look like yours, so please do this at a time that is convenient for you.

@chapkovski @mjonuzaj @asancetta 